### PR TITLE
add jupyterlab to dockerfile to work with paperspace

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,5 @@ FROM pytorch/pytorch:2.0.1-cuda11.7-cudnn8-devel
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y git pip ffmpeg libsm6 libxext6 wget unzip
 
+RUN pip install jupyterlab
 RUN pip install git+https://github.com/NVlabs/tiny-cuda-nn/#subdirectory=bindings/torch


### PR DESCRIPTION
# What is it?
adds installing jupyterlab to dockerfile

# How do I use it?
This container can be built, and pushed to a hub, and used with papespace gradient, which requires jupyter

# Future Work
N/A